### PR TITLE
Freeze textures on write

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
   hooks:
   - id: mypy
     args: [--python-version=3.10, --ignore-missing-imports]
+    additional_dependencies:
+    - types-requests
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.8.5
   hooks:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ with your own personalized list of custom player heads.
 
 ## Installation and Setup
 
+This package is compatible with Python 3.10 or newer. The only dependency
+required outside the standard library is
+[Requests](https://requests.readthedocs.io/en/latest/user/install/#install),
+which is included by default in many distributions and which is readily
+available from most system package managers as `python-requests` (or
+`python3-requests` for Debian/Ubuntu). As a fallback, you can always install it
+via [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/#use-pip-for-installing):
+```bash
+$ python3 -m pip install requests
+```
+
 To get started, it's recommended that you clone this repo to your computer:
 
 ```bash
@@ -21,7 +32,7 @@ You'll also need to grab yourself a copies of the Vanilla Tweaks data packs.
 
 ## Usage
 
-This package is compatible with Python 3.10 or newer and consists of four modules:
+The `head_hunter` package consists of four modules:
 
 1. `extract`, which extracts files from existing data packs
 1. `parse`, which parses head configurations from data pack functions and `/give` commands

--- a/Tutorial.ipynb
+++ b/Tutorial.ipynb
@@ -60,11 +60,11 @@
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/main/Workspace/head-hunter/head_hunter/extract.py:92: RuntimeWarning: Multiple packs match wanderingtrades*:\n",
+                        "/main/Workspace/head-hunter/head_hunter/extract.py:89: RuntimeWarning: Multiple packs match wanderingtrades*:\n",
                         " - packs/wandering trades hermit edition v1.8.3 (MC 1.20-1.20.4).zip\n",
-                        " - packs/wandering trades hermit edition v1.9.2 (MC 1.21.0).zip\n",
+                        " - packs/wandering trades hermit edition v1.9.3 (MC 1.21.0).zip\n",
                         "\n",
-                        "Extracting: packs/wandering trades hermit edition v1.9.2 (MC 1.21.0).zip\n",
+                        "Extracting: packs/wandering trades hermit edition v1.9.3 (MC 1.21.0).zip\n",
                         "  warnings.warn(message, RuntimeWarning)\n"
                     ]
                 }
@@ -127,11 +127,11 @@
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/main/Workspace/head-hunter/head_hunter/extract.py:92: RuntimeWarning: Multiple packs match wanderingtradeshermitedition*:\n",
+                        "/main/Workspace/head-hunter/head_hunter/extract.py:89: RuntimeWarning: Multiple packs match wanderingtradeshermitedition*:\n",
                         " - packs/wandering trades hermit edition v1.8.3 (MC 1.20-1.20.4).zip\n",
-                        " - packs/wandering trades hermit edition v1.9.2 (MC 1.21.0).zip\n",
+                        " - packs/wandering trades hermit edition v1.9.3 (MC 1.21.0).zip\n",
                         "\n",
-                        "Extracting: packs/wandering trades hermit edition v1.9.2 (MC 1.21.0).zip\n",
+                        "Extracting: packs/wandering trades hermit edition v1.9.3 (MC 1.21.0).zip\n",
                         "  warnings.warn(message, RuntimeWarning)\n"
                     ]
                 }
@@ -258,18 +258,6 @@
             "metadata": {},
             "outputs": [
                 {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "/main/Workspace/head-hunter/head_hunter/extract.py:92: RuntimeWarning: Multiple packs match moremobheads*:\n",
-                        " - packs/more mob heads v2.12.3 (MC 1.20-1.20.4).zip\n",
-                        " - packs/more mob heads v2.14.0 (MC 1.21.0).zip\n",
-                        "\n",
-                        "Extracting: packs/more mob heads v2.14.0 (MC 1.21.0).zip\n",
-                        "  warnings.warn(message, RuntimeWarning)\n"
-                    ]
-                },
-                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
@@ -299,6 +287,18 @@
                         "23 HeadSpec('Panda Head')\n",
                         "24 HeadSpec('Sniffer Head')\n",
                         "25 HeadSpec('Silverfish Head')\n"
+                    ]
+                },
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "/main/Workspace/head-hunter/head_hunter/extract.py:89: RuntimeWarning: Multiple packs match moremobheads*:\n",
+                        " - packs/more mob heads v2.12.3 (MC 1.20-1.20.4).zip\n",
+                        " - packs/more mob heads v2.14.0 (MC 1.21-1.21.1).zip\n",
+                        "\n",
+                        "Extracting: packs/more mob heads v2.14.0 (MC 1.21-1.21.1).zip\n",
+                        "  warnings.warn(message, RuntimeWarning)\n"
                     ]
                 }
             ],

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,12 @@ dependencies:
 - python==3.10
 - ipython>=8
 - pip>=24
+- requests
 - pre-commit
 - black
 - isort
 - mypy
+- types-requests
 - jupyterlab>=3
 - jupyterlab_code_formatter
 - pyperclip

--- a/head_hunter/_head_spec.py
+++ b/head_hunter/_head_spec.py
@@ -83,6 +83,11 @@ class HeadSpec(NamedTuple):
         -------
         LegacyHeadSpec
             The corresponding head spec
+
+        Raises
+        ------
+        ValueError
+            If the name provided is not a valid username
         """
         if not re.match(r"^[A-Za-z0-9_]{3,16}$", name):
             raise ValueError(f"{repr(name)} is not a valid Minecraft username")

--- a/head_hunter/mojang.py
+++ b/head_hunter/mojang.py
@@ -1,5 +1,7 @@
 """Functionality for interacting with the Mojang API"""
 
+import time
+import warnings
 from typing import Callable
 
 import requests
@@ -64,6 +66,12 @@ def _get_uuid_from_username(username: str) -> str:
             return response.json()["id"]
         case requests.codes.not_found:
             raise ValueError(response.json()["errorMessage"])
+        case requests.codes.too_many_requests:
+            warnings.warn(
+                "Getting rate limited. Sleeping for 10 seconds before trying again."
+            )
+            time.sleep(10)
+            return _get_uuid_from_username(username)
         case _:
             response.raise_for_status()
     raise requests.RequestException()
@@ -102,6 +110,12 @@ def _get_current_skin_from_uuid(uuid: str) -> str:
             raise ValueError(response.json()["errorMessage"])
         case requests.codes.no_content:
             raise ValueError(f"Couldn't find any profile with UUID {uuid}")
+        case requests.codes.too_many_requests:
+            warnings.warn(
+                "Getting rate limited. Sleeping for 10 seconds before trying again."
+            )
+            time.sleep(10)
+            return _get_current_skin_from_uuid(uuid)
         case _:
             response.raise_for_status()
     raise requests.RequestException()

--- a/head_hunter/mojang.py
+++ b/head_hunter/mojang.py
@@ -1,0 +1,136 @@
+"""Functionality for interacting with the Mojang API"""
+
+from typing import Callable
+
+import requests
+
+
+def _wrap_request_fail(api_call: Callable) -> Callable:
+    def wrapped(*args, **kwargs):
+        try:
+            return api_call(*args, **kwargs)
+        except requests.ConnectionError as bad_connection:
+            raise RuntimeError(
+                "Could not access Mojang API. Are you connected to the internet?"
+            ) from bad_connection
+        except requests.Timeout as timeout:
+            raise RuntimeError(
+                "Connection timed out trying to access Mojang API. Try again later?"
+            ) from timeout
+        except (
+            requests.RequestException,
+            requests.JSONDecodeError,
+            KeyError,
+        ) as bad_request:
+            raise RuntimeError(
+                "Something went wrong. Please report this problem to"
+                " https://github.com/OpenBagTwo/head-hunter/issues/new"
+            ) from bad_request
+
+    return wrapped
+
+
+@_wrap_request_fail
+def _get_uuid_from_username(username: str) -> str:
+    """Look up a player's UUID fromm their username
+
+    Parameters
+    ----------
+    username : str
+        A player's username
+
+    Returns
+    -------
+    str
+        The player's UUID
+
+    Raises
+    ------
+    ValueError
+        If no player with that username can be found
+    RuntimeError
+        If anything else goes wrong
+
+    Notes
+    -----
+    While this query is case-insensitive, this method does not check if the
+    provided username is valid
+    """
+    response = requests.get(
+        f"https://api.mojang.com/users/profiles/minecraft/{username}"
+    )
+    match response.status_code:
+        case requests.codes.ok:
+            return response.json()["id"]
+        case requests.codes.not_found:
+            raise ValueError(response.json()["errorMessage"])
+        case _:
+            response.raise_for_status()
+    raise requests.RequestException()
+
+
+@_wrap_request_fail
+def _get_current_skin_from_uuid(uuid: str) -> str:
+    """Get the current skin for the player with the specified UUID
+
+    Parameters
+    ----------
+    uuid : str
+        The player's UUID
+
+    Returns
+    -------
+    str
+        The player's skin, encoded in base64
+
+    Raises
+    ------
+    ValueError
+        If no player with that UUID can be found
+    RuntimeError
+        If anything else goes wrong
+    """
+    response = requests.get(
+        f"https://sessionserver.mojang.com/session/minecraft/profile/{uuid}"
+    )
+    match response.status_code:
+        case requests.codes.ok:
+            return {
+                item["name"]: item["value"] for item in response.json()["properties"]
+            }["textures"]
+        case requests.codes.bad_request:
+            raise ValueError(response.json()["errorMessage"])
+        case requests.codes.no_content:
+            raise ValueError(f"Couldn't find any profile with UUID {uuid}")
+        case _:
+            response.raise_for_status()
+    raise requests.RequestException()
+
+
+def get_players_current_skin(username: str) -> str:
+    """Grab a player's current skin
+
+    Parameters
+    ----------
+    username : str
+        A player's username
+
+    Returns
+    -------
+    str
+        The player's skin, encoded in base64
+
+    Raises
+    ------
+    ValueError
+        If no player with that username can be found
+    RuntimeError
+        If anything else goes wrong
+
+    Notes
+    -----
+    While this query is case-insensitive, this method does not check if the
+    provided username is valid
+    """
+    uuid = _get_uuid_from_username(username)
+    return _get_current_skin_from_uuid(uuid)

--- a/head_hunter/write.py
+++ b/head_hunter/write.py
@@ -99,6 +99,7 @@ def write_head_trades(
     purchase_limit: int = 3,
     xp_bonus: int = 0,
     pack_format: int = 48,
+    freeze_textures: bool = True,
 ) -> tuple[int, int]:
     """Render the `add_trade.mcfunction` file that will give the
     Wandering Trader a specified list of head trades
@@ -130,6 +131,13 @@ def write_head_trades(
         Minecraft 1.21 and above. To instead wreite the function for an older
         version of Minecraft, pass the pack format version here
         (see: https://minecraft.wiki/w/Data_pack#Pack_format).
+    freeze_textures : bool, optional
+        To avoid scenarios where traded heads have their textures dynamically
+        update—or worse, fail to fetch at all in-game—any trades that were
+        specified via username alone will have their current texture pulled
+        from the Mojang API when this method is called. To disable this
+        feature (for example, if you're running this on a computer without
+        internet access), pass in `freeze_textures=False`.
 
     Returns
     -------
@@ -189,9 +197,11 @@ def write_head_trades(
 
     for head in trades:
         head_spec = (
-            head.to_component_dict()
+            head.to_component_dict(offline=not freeze_textures)
             if pack_format >= 41
-            else head.to_player_head(pack_format=pack_format)
+            else head.to_player_head(
+                pack_format=pack_format, offline=not freeze_textures
+            )
         )
         command = command_template.replace(
             "IDX", str(trade_index := trade_index + 1)  # ++trade_index


### PR DESCRIPTION
I've been having an issue—across several computers and launchers and game versions—where heads provided via name alone are just assigned one of the default player skins.

Additionally, where I assumed that a player head provided via:
- `/give @p minecraft:player_head[profile={name:"OpenBagTwo"}]`, or
- `/give @p minecraft:player_head{SkullOwner:"OpenBagTwo"}`

would lock their texture on generation, I've observed that they actually just _always_ show the current texture. Sometimes, that's neat. Most of the time, though, it's not.

As a consequence, this PR adds functionality to [pull any unspecified skins](https://wiki.vg/Mojang_API#UUID_to_Profile_and_Skin.2FCape) based on [the player name](https://wiki.vg/Mojang_API#Username_to_UUID) from the Mojang API.

That does mean that this project now depends on the [Requests library](https://requests.readthedocs.io/en/latest/), but that's much a common package that I have absolutely no heartburn about requiring users to install it if they somehow don't have it already.

Note that this functionality _can_ be disabled by [passing in a kwarg](https://github.com/OpenBagTwo/head-hunter/blob/65d539e1af3620970d35460042331e7e355ddbd2/head_hunter/write.py#L134-L140) and that `requests` isn't imported until it's needed.